### PR TITLE
Implement CI in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
           - 'mariadb:10.6'
           - 'mariadb:10.7'
           - 'mariadb:latest'
-        # better readability on matrix job names than setting the env var content directly
-        asynciodebug:
-         - aiodebug
-         - no aiodebug
 
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -132,22 +128,20 @@ jobs:
 
         # timeout ensures a more or less clean stop by sending a KeyboardInterrupt which will still provide useful logs
         timeout --preserve-status --signal=INT --verbose 5m \
-          py.test --color=yes --capture=no --verbosity 2 --cov-report term --cov-report xml --cov  aiomysql ./tests
+          pytest --color=yes --capture=no --verbosity 2 --cov-report term --cov-report xml --cov  aiomysql ./tests
       env:
         PYTHONUNBUFFERED: 1
-        PYTHONASYNCIODEBUG: "${{ matrix.asynciodebug == 'aiodebug' && '1' || '' }}"
         MATRIX_DB: '${{ matrix.db }}'
       timeout-minutes: 6
 
     - name: Build coverage flag
       run: |
-        COVERAGE_FLAG="${MATRIX_OS}_${MATRIX_PY}_${MATRIX_DB//:/-}_${MATRIX_AIODEBUG// /-}"
+        COVERAGE_FLAG="${MATRIX_OS}_${MATRIX_PY}_${MATRIX_DB//:/-}"
         echo "COVERAGE_FLAG=$COVERAGE_FLAG" | tee -a "$GITHUB_ENV"
       env:
         MATRIX_OS: '${{ matrix.os }}'
         MATRIX_PY: '${{ matrix.py }}'
         MATRIX_DB: '${{ matrix.db }}'
-        MATRIX_AIODEBUG: "${{ matrix.asynciodebug }}"
 
     - name: Upload coverage
       uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,157 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+
+jobs:
+  test:
+    name: Test
+    strategy:
+      matrix:
+        # service containers are only supported on ubuntu currently
+        os:
+          - ubuntu-latest
+        py:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          # - '3.10'
+          # - '3.11.0-alpha.3'
+        db:
+          - 'mysql:5.7'
+          - 'mysql:8.0'
+          - 'mysql:latest'
+          - 'mariadb:10.2'
+          - 'mariadb:10.3'
+          - 'mariadb:10.4'
+          - 'mariadb:10.5'
+          - 'mariadb:10.6'
+          - 'mariadb:10.7'
+          - 'mariadb:latest'
+        # better readability on matrix job names than setting the env var content directly
+        asynciodebug:
+         - aiodebug
+         - no aiodebug
+
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    env:
+      MYSQL_ROOT_PASSWORD: rootpw
+
+    services:
+      mysql:
+        image: '${{ matrix.db }}'
+        ports:
+          - 3306:3306
+        options: '--name=mysqld'
+        env:
+          MYSQL_ROOT_PASSWORD: rootpw
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.4.0
+
+    - name: Setup Python ${{ matrix.py }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.py }}
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"    # - name: Cache
+
+    - name: Cache PyPI
+      uses: actions/cache@v2.1.7
+      with:
+        key: pip-ci-${{ runner.os }}-${{ matrix.py }}
+        path: ${{ steps.pip-cache.outputs.dir }}
+
+    - name: Update pip, wheel, setuptools, build, twine, codecov
+      run: |
+        python -m pip install -U pip wheel setuptools build twine codecov
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade --requirement requirements-dev.txt
+
+    - name: Install aiomysql
+      run: |
+        python -m pip install .
+
+    - name: Check rst
+      run: |
+        python setup.py check --restructuredtext
+
+    - name: Run pyroma
+      run: |
+        python -m pyroma -d .
+
+    # this ensures our database is ready. typically by the time the preparations have completed its first start logic.
+    # unfortunately we need this hacky workaround as GitHub Actions service containers can't reference data from our repo.
+    - name: Prepare mysql
+      run: |
+        # ensure server is started up
+        while :
+        do
+            sleep 1
+            mysql -h127.0.0.1 -uroot "-p$MYSQL_ROOT_PASSWORD" -e 'select version()' && break
+        done
+
+        # inject tls configuration
+        docker container stop mysqld
+        docker container cp "${{ github.workspace }}/tests/ssl_resources/ssl" mysqld:/etc/mysql/ssl
+        docker container cp "${{ github.workspace }}/tests/ssl_resources/tls.cnf" mysqld:/etc/mysql/conf.d/aiomysql-tls.cnf
+        docker container start mysqld
+
+        # ensure server is started up
+        while :
+        do
+            sleep 1
+            mysql -h127.0.0.1 -uroot "-p$MYSQL_ROOT_PASSWORD" -e 'select version()' && break
+        done
+
+        mysql -h127.0.0.1 -uroot "-p$MYSQL_ROOT_PASSWORD" -e "SET GLOBAL local_infile=on"
+
+    - name: Run tests
+      run: |
+        export DB="${MATRIX_DB%%:*}"
+        export DBTAG="${MATRIX_DB##*:}"
+
+        # timeout ensures a more or less clean stop by sending a KeyboardInterrupt which will still provide useful logs
+        timeout --preserve-status --signal=INT --verbose 5m \
+          py.test --color=yes --capture=no --verbosity 2 --cov-report term --cov-report xml --cov  aiomysql ./tests
+      env:
+        PYTHONUNBUFFERED: 1
+        PYTHONASYNCIODEBUG: "${{ matrix.asynciodebug == 'aiodebug' && '1' || '' }}"
+        MATRIX_DB: '${{ matrix.db }}'
+      timeout-minutes: 6
+
+    - name: Build coverage flag
+      run: |
+        COVERAGE_FLAG="${MATRIX_OS}_${MATRIX_PY}_${MATRIX_DB//:/-}_${MATRIX_AIODEBUG// /-}"
+        echo "COVERAGE_FLAG=$COVERAGE_FLAG" | tee -a "$GITHUB_ENV"
+      env:
+        MATRIX_OS: '${{ matrix.os }}'
+        MATRIX_PY: '${{ matrix.py }}'
+        MATRIX_DB: '${{ matrix.db }}'
+        MATRIX_AIODEBUG: "${{ matrix.asynciodebug }}"
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v2.1.0
+      with:
+        file: ./coverage.xml
+        flags: "${{ env.COVERAGE_FLAG }}"
+        fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,12 @@ jobs:
         db:
           - 'mysql:5.7'
           - 'mysql:8.0'
-          - 'mysql:latest'
           - 'mariadb:10.2'
           - 'mariadb:10.3'
           - 'mariadb:10.4'
           - 'mariadb:10.5'
           - 'mariadb:10.6'
           - 'mariadb:10.7'
-          - 'mariadb:latest'
 
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: lint
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"    # - name: Cache
+
+      - name: Cache PyPI
+        uses: actions/cache@v2.1.7
+        with:
+          key: pip-lint
+          path: ${{ steps.pip-cache.outputs.dir }}
+
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2.0.0
+        with:
+          flake8-version: 4.0.1
+          path: aiomysql
+          args: tests examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,9 @@
 language: python
 
-python:
-    - 3.6
-    - 3.7
-    - 3.8
-
 env:
     matrix:
         - PYTHONASYNCIODEBUG=1
         - PYTHONASYNCIODEBUG=
-
-services:
-    - docker
-
-matrix:
-   include:
-        - python: 3.6
-          env:
-            - PYTHONASYNCIODEBUG=
-            - DB=mariadb
-            - DBTAG=5.5
-        - python: 3.6
-          env:
-            - PYTHONASYNCIODEBUG=1
-            - DB=mariadb
-            - DBTAG=10.0
-          addons:
-              mariadb: '10.0'
-        - python: 3.6
-          env:
-            - PYTHONASYNCIODEBUG=
-            - DB=mariadb
-            - DBTAG=10.5
-        - python: 3.6
-          env:
-            - PYTHONASYNCIODEBUG=
-            - DB=mysql
-            - DBTAG=5.7
-
-
-#before_script:
-#    - "mysql -e 'SELECT VERSION()'"
-#    - "mysql -e 'DROP DATABASE IF EXISTS test_pymysql; create database test_pymysql  DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
-#    - "mysql -e 'DROP DATABASE IF EXISTS test_pymysql2; create database test_pymysql2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
-
-install:
-    - pip install -Ur requirements-dev.txt
-    - pip install .
-    - pip install codecov
 
 deploy:
     provider: pypi
@@ -60,9 +16,3 @@ deploy:
         repo: aio-libs/aiomysql
         all_branches: true
         python: 3.6
-
-script:
-    - make cov
-
-after_success:
-    - codecov

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 aiomysql
 ========
-.. image:: https://travis-ci.com/aio-libs/aiomysql.svg?branch=master
-    :target: https://travis-ci.com/aio-libs/aiomysql
+.. image:: https://github.com/aio-libs/aiomysql/actions/workflows/ci.yml/badge.svg?branch=master
+    :target: https://github.com/aio-libs/aiomysql/actions/workflows/ci.yml
 .. image:: https://codecov.io/gh/aio-libs/aiomysql/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/aio-libs/aiomysql
     :alt: Code coverage
@@ -104,7 +104,7 @@ for aiopg_ user.:
 Requirements
 ------------
 
-* Python_ 3.5.3+
+* Python_ 3.7+
 * PyMySQL_
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,16 +96,16 @@ Please feel free to file an issue on `bug tracker
 <https://github.com/aio-libs/aiomysql/issues>`_ if you have found a bug
 or have some suggestion for library improvement.
 
-The library uses `Travis <https://travis-ci.org/aio-libs/aiomysql>`_ for
-Continious Integration and `Coveralls
-<https://coveralls.io/r/aio-libs/aiomysql?branch=master>`_ for
+The library uses `GitHub Actions
+<https://github.com/aio-libs/aiomysql/actions>`_ for Continuous Integration
+and `Codecov <https://app.codecov.io/gh/aio-libs/aiomysql/branch/master>`_ for
 coverage reports.
 
 
 Dependencies
 ------------
 
-- Python 3.5.3+
+- Python 3.7+
 - :term:`PyMySQL`
 - aiomysql.sa requires :term:`sqlalchemy`.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,12 @@
-coverage>=4.5.1,<=5.1
-flake8>=3.5.0,<=3.7.9
-ipdb>=0.11,<=0.13.2
-ipython>=7.0.1,<=7.13.0
-pytest>=3.9.1,<=5.4.1
-pytest-cov>=2.6.0,<=2.8.1
-pytest-sugar>=0.9.1,<=0.9.3
+coverage==6.2
+flake8==4.0.1
+ipdb==0.13.9
+pytest==6.2.5
+pytest-cov==3.0.0
+pytest-sugar==0.9.4
 PyMySQL>=0.9,<=0.9.3
-docker>=3.5.1,<=4.2.0
 sphinx>=1.8.1, <=3.0.3
 sphinxcontrib-asyncio==0.2.0
 sqlalchemy>1.2.12,<=1.3.16
-uvloop>=0.11.2,<=0.14.0; python_version >= '3.5'
-pyroma==2.6
+uvloop==0.16.0
+pyroma==3.2

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ install_requires = ['PyMySQL>=0.9,<=0.9.3']
 PY_VER = sys.version_info
 
 
-if not PY_VER >= (3, 5, 3):
-    raise RuntimeError("aiomysql doesn't support Python earlier than 3.5.3")
+if not PY_VER >= (3, 7, 0):
+    raise RuntimeError("aiomysql doesn't support Python earlier than 3.7.0")
 
 
 def read(f):
@@ -37,8 +37,9 @@ classifiers = [
     'License :: OSI Approved :: MIT License',
     'Intended Audience :: Developers',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'Operating System :: POSIX',
     'Environment :: Web Environment',
     'Development Status :: 3 - Alpha',

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -29,7 +29,7 @@ async def test_issue_3(connection):
         assert r[0] is None
         await c.execute("select ts from issue3")
         r = await c.fetchone()
-        assert isinstance(r[0], datetime.datetime)
+        assert type(r[0]) in (type(None), datetime.datetime)
     finally:
         await c.execute("drop table issue3")
 

--- a/tests/test_load_local.py
+++ b/tests/test_load_local.py
@@ -6,7 +6,7 @@ import pytest
 from pymysql.err import OperationalError
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def table_local_file(connection, loop):
 
     async def prepare_table(conn):

--- a/tests/test_sha_connection.py
+++ b/tests/test_sha_connection.py
@@ -21,7 +21,7 @@ import pytest
 # ])
 
 
-@pytest.mark.mysql_verison('8.0')
+@pytest.mark.mysql_version('mysql', '8.0')
 @pytest.mark.run_loop
 async def test_sha256_nopw(mysql_server, loop):
     connection_data = copy.copy(mysql_server['conn_params'])
@@ -36,7 +36,7 @@ async def test_sha256_nopw(mysql_server, loop):
             assert conn._auth_plugin_used == 'sha256_password'
 
 
-@pytest.mark.mysql_verison('8.0')
+@pytest.mark.mysql_version('mysql', '8.0')
 @pytest.mark.run_loop
 async def test_sha256_pw(mysql_server, loop):
     connection_data = copy.copy(mysql_server['conn_params'])
@@ -51,7 +51,7 @@ async def test_sha256_pw(mysql_server, loop):
             assert conn._auth_plugin_used == 'sha256_password'
 
 
-@pytest.mark.mysql_verison('8.0')
+@pytest.mark.mysql_version('mysql', '8.0')
 @pytest.mark.run_loop
 async def test_cached_sha256_nopw(mysql_server, loop):
     connection_data = copy.copy(mysql_server['conn_params'])
@@ -66,7 +66,7 @@ async def test_cached_sha256_nopw(mysql_server, loop):
             assert conn._auth_plugin_used == 'caching_sha2_password'
 
 
-@pytest.mark.mysql_verison('8.0')
+@pytest.mark.mysql_version('mysql', '8.0')
 @pytest.mark.run_loop
 async def test_cached_sha256_pw(mysql_server, loop):
     connection_data = copy.copy(mysql_server['conn_params'])


### PR DESCRIPTION
- migrate travis CI tests to github actions
  - release publishing is not currently implemented
- drop python 3.5 and 3.6 support
- run tests for python 3.7 to 3.9
  - python 3.10 tests fail due to removed `loop` argument, therefore currently disabled
    - this is only an issue in the test suite afaik
  - python 3.11 tests currently fail to install `uvloop`, therefore currently disabled
    - see https://github.com/MagicStack/uvloop/issues/450
- run tests for MySQL 5.7 and 8.0 `latest`
- run tests for MariaDB 10.2 to 10.7 and `latest`
- bump dev/test dependencies
  - migrate deprecated test syntax
- remove docker integration from tests, for automated builds this is now covered by github actions
- async test methods have been broken before already https://app.travis-ci.com/github/aio-libs/aiomysql/jobs/448298144#L2340
- each matrix job is currently limited to 15 minutes total execution, it should be safe to expect the tests to be completed by then. in my tests (with pip cache) the tests usually run about 1.5 minutes.
- pytest job is soft limited to 5 minutes, hard limited to 6 minutes to avoid test hangs.
in my tests this is typically completed in less than a minute.
in broken tests we can easily deadlock otherwise and the test would otherwise keep running for hours.
- port fix for `test_issue_3` for MySQL 8.0 compatibility from https://github.com/PyMySQL/PyMySQL/pull/658
- `test_connection_gone_away` fails on MySQL 8.0
- `test_drop_connection_if_timedout` fails on MySQL 8.0, test was patched to close the pool to avoid blocking forever

open questions:
- is there any point in running a set of separate tests for `PYTHONASYNCIODEBUG=1`?
- should python 3.10 test compatibility be implemented in this PR or separately after this is merged?